### PR TITLE
Add FlakeHub rolling publishing

### DIFF
--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -1,0 +1,19 @@
+name: "Publish every Git push to main to FlakeHub"
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  flakehub-publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          name: "UbiqueLambda/devenv-elm"
+          rolling: true
+          visibility: "unlisted"


### PR DESCRIPTION
As “unlisted”, the flavors adjusted here are too personal for entering a public listing.