### PR TITLE
elm-review: accept params in a file

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -38,7 +38,7 @@
           toString (pkgs.writeShellScript "env-elm-review" ''
             exec ${binReview} \
               --template ${lib.strings.escapeShellArg reviewTemplate} \
-              $(cat \"$DEVENV_ROOT/.elm-review\" || true);
+              $(cat "''${DEVENV_ROOT:-.}/.elm-review" || true);
           '');
       };
     };

--- a/common.nix
+++ b/common.nix
@@ -35,11 +35,11 @@
       reviewCmd = mkOption {
         type = lib.types.str;
         default = with config.languages.elm;
-          toString pkgs.writeShellScript "env-elm-review" ''
+          toString (pkgs.writeShellScript "env-elm-review" ''
             exec ${binReview} \
               --template ${lib.strings.escapeShellArg reviewTemplate} \
               $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
-          '';
+          '');
       };
     };
   };

--- a/common.nix
+++ b/common.nix
@@ -35,7 +35,7 @@
       reviewCmd = mkOption {
         type = lib.types.str;
         default = with config.languages.elm;
-          pkgs.writeShellScript "env-elm-review" ''
+          toString pkgs.writeShellScript "env-elm-review" ''
             exec ${binReview} \
               --template ${lib.strings.escapeShellArg reviewTemplate} \
               $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
@@ -65,7 +65,7 @@
         };
         elm-review = {
           enable = true;
-          entry = mkForce "${reviewCmd}";
+          entry = mkForce reviewCmd;
           files = mkForce files;
         };
         nixpkgs-fmt = {

--- a/common.nix
+++ b/common.nix
@@ -38,7 +38,7 @@
           toString (pkgs.writeShellScript "env-elm-review" ''
             exec ${binReview} \
               --template ${lib.strings.escapeShellArg reviewTemplate} \
-              $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
+              $(cat \"$DEVENV_ROOT/.elm-review\" || true);
           '');
       };
     };

--- a/common.nix
+++ b/common.nix
@@ -35,7 +35,7 @@
       reviewCmd = mkOption {
         type = lib.types.str;
         default = with config.languages.elm;
-          "${binReview} --template ${lib.strings.escapeShellArg reviewTemplate}";
+          "${binReview} --template ${lib.strings.escapeShellArg reviewTemplate} $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
       };
     };
   };

--- a/common.nix
+++ b/common.nix
@@ -35,7 +35,11 @@
       reviewCmd = mkOption {
         type = lib.types.str;
         default = with config.languages.elm;
-          "${binReview} --template ${lib.strings.escapeShellArg reviewTemplate} $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
+          pkgs.writeShellScript "env-elm-review" ''
+            exec ${binReview} \
+              --template ${lib.strings.escapeShellArg reviewTemplate} \
+              $(cat \"$DEVENV_ROOT/.elm-review\" || true)";
+          '';
       };
     };
   };


### PR DESCRIPTION
For easily managing “ignores” per-project.